### PR TITLE
fix(build): sha3 -> sha256, add externs.js

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@
 
 SQLITE_AMALGAMATION = sqlite-amalgamation-3350500
 SQLITE_AMALGAMATION_ZIP_URL = https://www.sqlite.org/2021/${SQLITE_AMALGAMATION}.zip
-SQLITE_AMALGAMATION_ZIP_SHA3 = 8175cba8e28c2274aa6f8305076116622a4ecb7829673b92290dc047fba9bba6
+SQLITE_AMALGAMATION_ZIP_SHA = b49409ef123e193e719e2536f9b795482a69e61a9cc728933739b9024f035061
 
 EXTENSION_FUNCTIONS = extension-functions.c
 EXTENSION_FUNCTIONS_URL = https://www.sqlite.org/contrib/download/extension-functions.c?get=25
-EXTENSION_FUNCTIONS_SHA3 = ee39ddf5eaa21e1d0ebcbceeab42822dd0c4f82d8039ce173fd4814807faabfa
+EXTENSION_FUNCTIONS_SHA = 991b40fe8b2799edc215f7260b890f14a833512c9d9896aa080891330ffe4052
 
 # source files
 
@@ -25,7 +25,7 @@ BITCODE_FILES = \
 
 # build options
 
-EMCC ?= emcc
+EMCC ?= EMCC_CLOSURE_ARGS="--externs externs.js" emcc
 
 CFLAGS = \
 	-O3 \
@@ -121,17 +121,17 @@ deps: deps/$(SQLITE_AMALGAMATION) deps/$(EXTENSION_FUNCTIONS) deps/$(EXPORTED_FU
 
 deps/$(SQLITE_AMALGAMATION): cache/$(SQLITE_AMALGAMATION).zip
 	mkdir -p deps
-	openssl dgst -sha3-256 -r cache/$(SQLITE_AMALGAMATION).zip | sed -e 's/\s.*//' > deps/sha3
-	echo $(SQLITE_AMALGAMATION_ZIP_SHA3) | cmp deps/sha3
-	rm -rf deps/sha3 $@
+	openssl dgst -sha256 -r cache/$(SQLITE_AMALGAMATION).zip | awk '{print $$1}' > deps/sha
+	echo $(SQLITE_AMALGAMATION_ZIP_SHA) | cmp deps/sha
+	rm -rf deps/sha $@
 	unzip 'cache/$(SQLITE_AMALGAMATION).zip' -d deps/
 	touch $@
 
 deps/$(EXTENSION_FUNCTIONS): cache/$(EXTENSION_FUNCTIONS)
 	mkdir -p deps
-	openssl dgst -sha3-256 -r cache/$(EXTENSION_FUNCTIONS) | sed -e 's/\s.*//' > deps/sha3
-	echo $(EXTENSION_FUNCTIONS_SHA3) | cmp deps/sha3
-	rm -rf deps/sha3 $@
+	openssl dgst -sha256 -r cache/$(EXTENSION_FUNCTIONS) | awk '{print $$1}' > deps/sha
+	echo $(EXTENSION_FUNCTIONS_SHA) | cmp deps/sha
+	rm -rf deps/sha $@
 	cp 'cache/$(EXTENSION_FUNCTIONS)' $@
 
 ## tmp

--- a/externs.js
+++ b/externs.js
@@ -1,0 +1,2 @@
+// @externs
+var dynCall_v;


### PR DESCRIPTION
I've tried to build and run it on Mac and stumbled upon some issues. Here's the fixes:

<details>
<summary>Use sha256 instead of sha3</summary>

### It's not possible to use sha3 inside `openssl` on Mac:
```console
➜ wa-sqlite (master) ✔ make
mkdir -p cache
curl -LsSf 'https://www.sqlite.org/2021/sqlite-amalgamation-3350500.zip' -o cache/sqlite-amalgamation-3350500.zip

mkdir -p deps
openssl dgst -sha3-256 -r cache/sqlite-amalgamation-3350500.zip | sed -e 's/\s.*//' > deps/sha3
unknown option '-sha3-256'
options are
-c              to output the digest with separating colons
-r              to output the digest in coreutils format
-d              to output debug info
-hex            output as hex dump
-binary         output in binary form
-sign   file    sign digest using private key in file
-verify file    verify a signature using public key in file
-prverify file  verify a signature using private key in file
-keyform arg    key file format (PEM)
-out filename   output to filename rather than stdout
-signature file signature to verify
-sigopt nm:v    signature parameter
-hmac key       create hashed MAC with key
-mac algorithm  create MAC (not neccessarily HMAC)
-macopt nm:v    MAC algorithm parameters or key
-gost-mac       to use the gost-mac message digest algorithm
-streebog512    to use the streebog512 message digest algorithm
-streebog256    to use the streebog256 message digest algorithm
-md_gost94      to use the md_gost94 message digest algorithm
-md4            to use the md4 message digest algorithm
-md5            to use the md5 message digest algorithm
-md5-sha1       to use the md5-sha1 message digest algorithm
-ripemd160      to use the ripemd160 message digest algorithm
-sha1           to use the sha1 message digest algorithm
-sha224         to use the sha224 message digest algorithm
-sha256         to use the sha256 message digest algorithm
-sha384         to use the sha384 message digest algorithm
-sha512         to use the sha512 message digest algorithm
-whirlpool      to use the whirlpool message digest algorithm
echo 8175cba8e28c2274aa6f8305076116622a4ecb7829673b92290dc047fba9bba6 | cmp deps/sha3
cmp: EOF on deps/sha3
make: *** [deps/sqlite-amalgamation-3350500] Error 1
```
</details>

<details>
<summary>Add missing externs</summary>

### Some externs are missing (https://github.com/emscripten-core/emscripten/issues/13858)

```console
building:ERROR: Closure compiler run failed:

building:ERROR: tmpowbsmfov.js:783:5: ERROR - [JSC_UNDEFINED_VARIABLE] variable dynCall_v is undeclared
  783|      dynCall_v.call(null, func);
            ^^^^^^^^^

1 error(s), 0 warning(s)

emcc: error: closure compiler failed (rc: 1): /usr/local/bin/node --max_old_space_size=8192 /usr/local/Cellar/emscripten/2.0.20/libexec/node_modules/.bin/google-closure-compiler --compilation_level ADVANCED_OPTIMIZATIONS --language_in ECMASCRIPT_2020 --language_out NO_TRANSPILE --emit_use_strict=false --externs tmpnq0od9q7.js --externs tmploe52i6d.js --externs tmpde11vwny.js --externs tmpydfw1_zu.js --externs tmp1786c34t.js --externs tmpjctpq033.js --externs tmp0co9vol5.js --externs tmpb0yn98f6.js --externs tmpu14jnf9q.js --externs tmp23g5n9l7.js --externs tmpwd2be6he.js --externs tmp5gt_1b6i.js --externs tmpvnfxipgi.js --externs tmpajgso7ez.js --externs tmpadrxoa8r.js --externs tmp84guazt7.js --externs tmpqsouv949.js --externs tmpbfq5nvc4.js --externs tmpta3ug0w4.js --externs tmpnaakckys.js --externs tmp61jto415.js --externs tmp5q1efroq.js --externs tmpdmqdtef1.js --externs tmpgglfriq8.js --externs tmphqhg0snk.js --externs tmp6lrhf5l7.js --externs tmphl58w_dg.js --externs tmpexsmakc0.js --externs tmpmqav7ccs.js --externs tmpl644_z48.js --externs tmp7_d3hjrb.js --externs tmp6273n3p4.js --js_output_file tmpwulec6ec.cc.js --js tmpowbsmfov.js the error message may be clearer with -g1 and EMCC_DEBUG=2 set
make: *** [dist/wa-sqlite-async.mjs] Error 1
```
</details>