### PR TITLE
Print VFS name in error

### DIFF
--- a/src/libvfs.js
+++ b/src/libvfs.js
@@ -11,7 +11,7 @@ const vfs_methods = {
       const vfsAlreadyRegistered = ccall('sqlite3_vfs_find', 'number', ['string'],
         [vfs.name]);
       if (vfsAlreadyRegistered) {
-        throw Error(`VFS '${vfs}' already registered`);
+        throw Error(`VFS '${vfs.name}' already registered`);
       }
 
       if (hasAsyncify) {


### PR DESCRIPTION
I was getting `VFS '[object Object]' already registered`, which was relatively uninformative.

(Nuking my repo via `git clean -xdf` fixed the issue - not sure what the real problem was. Probably something got cached.)

>In order to preserve licensing rights, this repository generally does
>not accept unsolicited pull requests.

> * Bugs should be filed to [Issues](https://github.com/rhashimoto/wa-sqlite/issues).
> * New features should be proposed in [Discussions](https://github.com/rhashimoto/wa-sqlite/discussions).
>* New extensions (modules and virtual filesystems) are encouraged to get their own repo.

> Thanks!

Yeah, I'm aware, but felt like this was the best way to submit feedback. Feel free to close/not accept or whatever.