### PR TITLE
Align SharedService implementations.

### DIFF
--- a/demo/SharedService-sw/index.js
+++ b/demo/SharedService-sw/index.js
@@ -38,7 +38,7 @@ navigator.serviceWorker.register('SharedService_ServiceWorker.js');
 
 // Create the shared service.
 log('start');
-const sharedService = new SharedService('test', portProvider);
+const sharedService = new SharedService('test-sw', portProvider);
 sharedService.activate();
 
 for (const button of Array.from(document.getElementsByTagName('button'))) {

--- a/demo/SharedService/SharedService_SharedWorker.js
+++ b/demo/SharedService/SharedService_SharedWorker.js
@@ -1,32 +1,23 @@
-/** @type {Map<string, MessagePort>} */
-const mapNameToProviderPort = new Map();
-
-const broadcast = new BroadcastChannel('SharedService');
+/** @type {Map<string, MessagePort>} */ const mapClientIdToPort = new Map();
 
 globalThis.addEventListener('connect', event => {
+  // The first message from a client associates the clientId with the port.
   const workerPort = event.ports[0];
-  workerPort.addEventListener('message', async event => {
-    if (event.ports.length) {
-      // Register new port provider.
-      const name = event.data;
-      const providerPort = event.ports[0];
-      providerPort.start();
-      mapNameToProviderPort.get(name)?.close();
-      mapNameToProviderPort.set(name, providerPort);
+  workerPort.addEventListener('message', event => {
+    mapClientIdToPort.set(event.data.clientId, workerPort);
 
-      broadcast.postMessage(name);
-    } else {
-      // Handle port provider request.
-      const { name, lockId } = event.data;
-      const providerPort = mapNameToProviderPort.get(name);
-      if (providerPort) {
-        providerPort.addEventListener('message', event => {
-          event.stopImmediatePropagation();
-          workerPort.postMessage(null, event.ports);
-        }, { once: true });
-        providerPort.postMessage(lockId);
-      }
-    }
-  });
+    // Remove the entry when the client goes away, which we detect when
+    // the lock on its name becomes available.
+    navigator.locks.request(event.data.clientId, { mode: 'shared' }, () => {
+      mapClientIdToPort.get(event.data.clientId)?.close();
+      mapClientIdToPort.delete(event.data.clientId);
+    });
+
+    // Subsequent messages will be forwarded.
+    workerPort.addEventListener('message', event => {
+      const port = mapClientIdToPort.get(event.data.clientId);
+      port.postMessage(event.data, event.ports);
+    });
+  }, { once: true });
   workerPort.start();
 });


### PR DESCRIPTION
This unifies the two SharedService implementations. Only the SharedService methods `#getClientId()` and `#sendPortToClient()` now depend on the mechanism (SharedWorker or service worker) to establish the MessageChannel to the service.