### PR TITLE
remove unused `deps` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,9 +124,6 @@ cache/$(EXTENSION_FUNCTIONS):
 clean-deps:
 	rm -rf deps
 
-.PHONY: deps
-deps: deps/$(SQLITE_AMALGAMATION) deps/$(EXTENSION_FUNCTIONS)
-
 deps/$(SQLITE_VERSION)/sqlite3.h deps/$(SQLITE_VERSION)/sqlite3.c:
 	mkdir -p cache/$(SQLITE_VERSION)
 	curl -LsS $(SQLITE_TARBALL_URL) | tar -xzf - -C cache/$(SQLITE_VERSION)/ --strip-components=1


### PR DESCRIPTION
Was getting an error about being unable to make `deps` for target `deps` when these lines were included.

Likely since the amalgamation variable was undefined it was looking for a `deps/` directory for the `deps` target.

### Checklist
- [x] I grant to recipients of this Project distribution a perpetual,
non-exclusive, royalty-free, irrevocable copyright license to reproduce, prepare
derivative works of, publicly display, sublicense, and distribute this
Contribution and such derivative works.
- [x] I certify that I am legally entitled to grant this license, and that this
Contribution contains no content requiring a license from any third party.
