### PR TITLE
Bugfix: Avoid dot notation in minified Javascript

### DIFF
--- a/src/libvfs.js
+++ b/src/libvfs.js
@@ -22,7 +22,7 @@ const vfs_methods = {
         vfs['handleAsync'] = Asyncify.handleAsync;
       }
 
-      const mxPathName = vfs.mxPathName ?? 64;
+      const mxPathName = vfs['mxPathName'] ?? 64;
       const out = Module['_malloc'](4);
       const result = ccall('register_vfs', 'number', ['string', 'number', 'number', 'number'],
         [vfs.name, mxPathName, makeDefault ? 1 : 0, out]);


### PR DESCRIPTION
It is better to use `[]` for object access in Javascript code that is processed by Emscripten.

The Javascript libraries passed to emcc are being minified with Google's [Closure
Compiler](https://developers.google.com/closure/compiler) due to the `--closure 1` parameter.
The closure compiler minifies keys on objects.

```js
const mxPathName = vfs.mxPathName ?? 64;
```

is minified as

```js
var n=h.Lg??64;
```

where `h.Lg` is undefined, so `n` will always be `64`.

With this change, the minified output is

```js
var n=h.mxPathName??64;
```

### Checklist
- [x] I grant to recipients of this Project distribution a perpetual,
non-exclusive, royalty-free, irrevocable copyright license to reproduce, prepare
derivative works of, publicly display, sublicense, and distribute this
Contribution and such derivative works.
- [x] I certify that I am legally entitled to grant this license, and that this
Contribution contains no content requiring a license from any third party.
