### PR TITLE
Fix 168: Handle empty blobs as bind parameters

### DIFF
--- a/src/sqlite-api.js
+++ b/src/sqlite-api.js
@@ -138,7 +138,12 @@ export function Factory(Module) {
       verifyStatement(stmt);
       // @ts-ignore
       const byteLength = value.byteLength ?? value.length;
-      const ptr = Module._sqlite3_malloc(byteLength);
+
+      // Allocate empty buffer in the case of zero-length
+      // bytearray to differentiate from NULL
+      const ptr = byteLength === 0 ?
+        createUTF8('') :
+        Module._sqlite3_malloc(byteLength);
       Module.HEAPU8.subarray(ptr).set(value);
       const result = f(stmt, i, ptr, byteLength, sqliteFreeAddress);
       // trace(fname, result);


### PR DESCRIPTION
Fixes issue https://github.com/rhashimoto/wa-sqlite/issues/168 where empty bytearrays/blobs were being encoded as NULLs when using the `bind_blob` method.

There was already a test covering empty blob writing and reading but not using bind parameters. I've added an additional test for blobs with bind parameters similar to the one for the 64-bit integers that fails without the suggested fix.

An alternative approach would be to write
```js
const ptr = byteLength === 0 ?
        Module._sqlite3_malloc(1) :
        Module._sqlite3_malloc(byteLength);
```
but I find using the UTF8 utility to allocate an "empty buffer" to be clearer in terms of intent.

Similar issue with similar resolution in [better-sqlite3](https://github.com/Prinzhorn/better-sqlite3):
https://github.com/WiseLibs/better-sqlite3/issues/651
https://github.com/Prinzhorn/better-sqlite3/commit/3cbe134f0c112ced301ee4081db7c3afdf6b685b

### Checklist
- [x] I grant to recipients of this Project distribution a perpetual,
non-exclusive, royalty-free, irrevocable copyright license to reproduce, prepare
derivative works of, publicly display, sublicense, and distribute this
Contribution and such derivative works.
- [x] I certify that I am legally entitled to grant this license, and that this
Contribution contains no content requiring a license from any third party.
