### PR TITLE
Fix xUnlock() call without prior call to xLock()

### DIFF
--- a/src/examples/OPFSAdaptiveVFS.js
+++ b/src/examples/OPFSAdaptiveVFS.js
@@ -413,7 +413,7 @@ export class OPFSAdaptiveVFS extends WebLocksMixin(FacadeVFS) {
       this.lastError = e;
       return VFS.SQLITE_IOERR;
     }
-    return VFS.SQLITE_NOTFOUND;
+    return super.jFileControl(fileId, op, pArg);
   }
 
   jGetLastError(zBuf) {


### PR DESCRIPTION
SQLite will sometimes call xUnlock() without previously calling xLock() - this can happen when the first query does not actually access the database file. This surprised WebLocksMixIn.jUnlock(), which was expecting state to already exist.