### PR TITLE
IDBMirrorVFS: Fix database corruption caused by unfilled blocks

### DIFF
--- a/src/examples/IDBMirrorVFS.js
+++ b/src/examples/IDBMirrorVFS.js
@@ -333,6 +333,10 @@ export class IDBMirrorVFS extends FacadeVFS {
 
       if (file.flags & VFS.SQLITE_OPEN_MAIN_DB) {
         this.#requireTxActive(file);
+        // SQLite is not necessarily written sequentially, we fill in the unwritten blocks here
+        for (let fillOffset = file.txActive.fileSize; fillOffset < iOffset; fillOffset += pData.byteLength) {
+          file.txActive.blocks.set(fillOffset, new Uint8Array(pData.byteLength));
+        }
         file.txActive.blocks.set(iOffset, pData.slice());
         file.txActive.fileSize = Math.max(file.txActive.fileSize, iOffset + pData.byteLength);
         file.blockSize = pData.byteLength;

--- a/src/examples/IDBMirrorVFS.js
+++ b/src/examples/IDBMirrorVFS.js
@@ -333,8 +333,10 @@ export class IDBMirrorVFS extends FacadeVFS {
 
       if (file.flags & VFS.SQLITE_OPEN_MAIN_DB) {
         this.#requireTxActive(file);
-        // SQLite is not necessarily written sequentially, we fill in the unwritten blocks here
-        for (let fillOffset = file.txActive.fileSize; fillOffset < iOffset; fillOffset += pData.byteLength) {
+        // SQLite is not necessarily written sequentially, so fill in the
+        // unwritten blocks here.
+        for (let fillOffset = file.txActive.fileSize;
+             fillOffset < iOffset; fillOffset += pData.byteLength) {
           file.txActive.blocks.set(fillOffset, new Uint8Array(pData.byteLength));
         }
         file.txActive.blocks.set(iOffset, pData.slice());


### PR DESCRIPTION
See https://github.com/rhashimoto/wa-sqlite/issues/258#issuecomment-2780181761

Steps to reproduce: 

1. Open <https://rhashimoto.github.io/wa-sqlite/demo/?build=asyncify&config=IDBMirrorVFS>
2. Fill in the following sql statement：
```sql
PRAGMA page_size=65536;

CREATE TABLE IF NOT EXISTS large_blobs  (
    id INTEGER PRIMARY KEY,
    data BLOB
);

INSERT INTO large_blobs(data) VALUES (randomblob(100 * 1024 * 1024));
INSERT INTO large_blobs(data) VALUES (randomblob(100 * 1024 * 1024));
INSERT INTO large_blobs(data) VALUES (randomblob(100 * 1024 * 1024));
INSERT INTO large_blobs(data) VALUES (randomblob(100 * 1024 * 1024));
INSERT INTO large_blobs(data) VALUES (randomblob(100 * 1024 * 1024));
INSERT INTO large_blobs(data) VALUES (randomblob(100 * 1024 * 1024));
INSERT INTO large_blobs(data) VALUES (randomblob(100 * 1024 * 1024));
INSERT INTO large_blobs(data) VALUES (randomblob(100 * 1024 * 1024));
INSERT INTO large_blobs(data) VALUES (randomblob(100 * 1024 * 1024));
INSERT INTO large_blobs(data) VALUES (randomblob(100 * 1024 * 1024));
```
3. After the run is complete, refresh the interface and run again
4. A "database disk image is malformed" error occurs