### PR TITLE
Fix IDBBatchAtomicVFS race condition

### DIFF
--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -8,9 +8,12 @@ export default /** @type {import("@web/test-runner").TestRunnerConfig} */ ({
       defaultTimeoutInterval: 5 * 60 * 1000
     },
   },
+  browserLogs: true,
+  browserStartTimeout: 60_000,
   nodeResolve: true,
   files: ['./test/*.test.js'],
   concurrency: 1,
+  concurrentBrowsers: 1,
   browsers: [
     chromeLauncher({
       launchOptions: {


### PR DESCRIPTION
IDBBatchAtomicVFS had a race condition where a transaction could be used when the transaction was completed but before the "complete" event was delivered. When this happened an exception would be thrown without a retry. The fix is to retry on this condition.

This error was exposed in a unit test that makes direct VFS calls, i.e. not via SQLite.