### PR TITLE
Fix resetting `isHandleRequested` in `OPFSCoopSyncVFS`

### DIFF
--- a/src/examples/OPFSCoopSyncVFS.js
+++ b/src/examples/OPFSCoopSyncVFS.js
@@ -437,7 +437,7 @@ export class OPFSCoopSyncVFS extends FacadeVFS {
         if (file.persistentFile.isHandleRequested) {
             // Another connection wants the access handle.
           this.#releaseAccessHandle(file);
-          this.isHandleRequested = false;
+          file.persistentFile.isHandleRequested = false;
         }
         file.persistentFile.isFileLocked = false;
       }


### PR DESCRIPTION
`isHandleRequested` is a property on `PersistedFile`, not the VFS itself.

We've seen this cause an infinite loop when a statement is backed by a SQLite extension / application-defined function using their own statements internally (because a single `step` call may then cause multiple lock / unlock operations internally). So the `unlock` call should not give up the access handle right away, because a subsequent lock then returns `SQLITE_BUSY`, causing us to retry this call (which again unlocks + locks later, repeating this indefinitely).
