### PR TITLE
Permit JS booleans to be bound to queries, as integer 0/1 values

### DIFF
--- a/src/sqlite-api.js
+++ b/src/sqlite-api.js
@@ -118,6 +118,8 @@ export function Factory(Module) {
         }
       case 'string':
         return sqlite3.bind_text(stmt, i, value);
+      case "boolean":
+        return sqlite3.bind_int(stmt, i, value ? 1 : 0);
       default:
         if (value instanceof Uint8Array || Array.isArray(value)) {
           return sqlite3.bind_blob(stmt, i, value);

--- a/test/api_statements.js
+++ b/test/api_statements.js
@@ -238,6 +238,27 @@ export function api_statements(context) {
       }
     });
 
+    it('should bind boolean', async function() {
+      let rc;
+      const sql = 'SELECT ?';
+      const storeValue = true;
+      const expectedRetrievedValue = 1;
+
+      for await (const stmt of i(sqlite3.statements(db, sql))) {
+        // Comlink intercepts the 'bind' property so use an alias.
+        rc = await sqlite3.bind$(stmt, 1, storeValue);
+        expect(rc).toEqual(SQLite.SQLITE_OK);
+
+        while ((rc = await sqlite3.step(stmt)) !== SQLite.SQLITE_DONE) {
+          expect(rc).toEqual(SQLite.SQLITE_ROW);
+
+          expect(await sqlite3.column_count(stmt)).toEqual(1);
+          expect(await sqlite3.column_type(stmt, 0)).toEqual(SQLite.SQLITE_INTEGER);
+          expect(await sqlite3.column_int(stmt, 0)).toEqual(expectedRetrievedValue);
+        }
+      }
+    });
+
     it('should bind collection array', async function() {
       let rc;
       const sql = 'VALUES (?, ?, ?, ?, ?)';


### PR DESCRIPTION
While SQLite does not recognize booleans as a separate data type (https://sqlite.org/datatype3.html), it does support `BOOL` column types, and the magic strings `TRUE` and `FALSE`, which actually store an integer 0 or 1.  It seems useful to permit JS booleans to be bound to queries to support this.

### Checklist
- [x] I grant to recipients of this Project distribution a perpetual,
non-exclusive, royalty-free, irrevocable copyright license to reproduce, prepare
derivative works of, publicly display, sublicense, and distribute this
Contribution and such derivative works.
- [x] I certify that I am legally entitled to grant this license, and that this
Contribution contains no content requiring a license from any third party.
