### PR TITLE
`MemoryVFS` should avoid creating `Proxy` objects in `makeDataArray`

### DIFF
--- a/src/FacadeVFS.js
+++ b/src/FacadeVFS.js
@@ -285,7 +285,7 @@ export class FacadeVFS extends VFS.Base {
    * @returns {number|Promise<number>}
    */
   xRead(pFile, pData, iAmt, iOffsetLo, iOffsetHi) {
-    const pDataArray = this.#makeDataArray(pData, iAmt);
+    const pDataArray = this.makeDataArray(pData, iAmt);
     const iOffset = delegalize(iOffsetLo, iOffsetHi);
     this['log']?.('jRead', pFile, iAmt, iOffset);
     return this.jRead(pFile, pDataArray, iOffset);
@@ -300,7 +300,7 @@ export class FacadeVFS extends VFS.Base {
    * @returns {number|Promise<number>}
    */
   xWrite(pFile, pData, iAmt, iOffsetLo, iOffsetHi) {
-    const pDataArray = this.#makeDataArray(pData, iAmt);
+    const pDataArray = this.makeDataArray(pData, iAmt);
     const iOffset = delegalize(iOffsetLo, iOffsetHi);
     this['log']?.('jWrite', pFile, pDataArray, iOffset);
     return this.jWrite(pFile, pDataArray, iOffset);
@@ -451,7 +451,7 @@ export class FacadeVFS extends VFS.Base {
    * @param {number} byteOffset 
    * @param {number} byteLength 
    */
-  #makeDataArray(byteOffset, byteLength) {
+  makeDataArray(byteOffset, byteLength) {
     let target = this._module.HEAPU8.subarray(byteOffset, byteOffset + byteLength);
     return new Proxy(target, {
       get: (_, prop, receiver) => {

--- a/src/examples/MemoryVFS.js
+++ b/src/examples/MemoryVFS.js
@@ -173,4 +173,14 @@ export class MemoryVFS extends FacadeVFS {
     pResOut.setInt32(0, file ? 1 : 0, true);
     return VFS.SQLITE_OK;
   }
+
+  /**
+   * Override the base makeDataArray to not watch for WebAssembly memory resize.
+   * as we always use the memory immediately.
+   * @param {number} byteOffset 
+   * @param {number} byteLength 
+   */
+  makeDataArray(byteOffset, byteLength) {
+    return this._module.HEAPU8.subarray(byteOffset, byteOffset + byteLength);
+  }
 }


### PR DESCRIPTION
This is a performance improvement, for the `MemoryVFS` (and `MemoryAsyncVFS`).

Currently the `FacadeVFS` protects against WASM memory resizing by wrapping the data arrays passed to `jRead` and `jWrite` with a `Proxy` object.  This instance creation for every IO operation is quite heavy, and for the `MemoryVFS` is unnecessary as the data arrays are consumed immediately.

I've avoided this by overriding the `makeDataArray` to always point to the underlying WASM memory.  And it's _much_ faster - 40x faster for 1000 inserts!

![makeDataArray-no-proxy](https://github.com/user-attachments/assets/5e1dc274-870d-46c7-a590-cfc6f6829015)


### Checklist
- [x] I grant to recipients of this Project distribution a perpetual,
non-exclusive, royalty-free, irrevocable copyright license to reproduce, prepare
derivative works of, publicly display, sublicense, and distribute this
Contribution and such derivative works.
- [x] I certify that I am legally entitled to grant this license, and that this
Contribution contains no content requiring a license from any third party.
