### PR TITLE
Use a single `TextEncoder` instance

### DIFF
--- a/src/sqlite-api.js
+++ b/src/sqlite-api.js
@@ -34,11 +34,12 @@ export function Factory(Module) {
   const tmp = Module._malloc(8);
   const tmpPtr = [tmp, tmp + 4];
 
+  const textEncoder = new TextEncoder();
   // Convert a JS string to a C string. sqlite3_malloc is used to allocate
   // memory (use sqlite3_free to deallocate).
   function createUTF8(s) {
     if (typeof s !== 'string') return 0;
-    const utf8 = new TextEncoder().encode(s);
+    const utf8 = textEncoder.encode(s);
     const zts = Module._sqlite3_malloc(utf8.byteLength + 1);
     Module.HEAPU8.set(utf8, zts);
     Module.HEAPU8[zts + utf8.byteLength] = 0;
@@ -661,7 +662,7 @@ export function Factory(Module) {
       const onFinally = [];
       try {
         // Encode SQL string to UTF-8.
-        const utf8 = new TextEncoder().encode(sql);
+        const utf8 = textEncoder.encode(sql);
 
         // Copy encoded string to WebAssembly memory. The SQLite docs say
         // zero-termination is a minor optimization so add room for that.


### PR DESCRIPTION
This is a minor performance improvement.  Currently a new `TextEncoder` instance is created for every JS string that is encoded into a byte array.  Creating new instances every time is unnecessary AFAICT, and a single `TextEncoder` can be used for all conversions.

I've added a new benchmark to demonstrate the impact of this (see the bottom table row) - it's fairly minor, but measurable in our workflow.

<img width="884" alt="single-textencoder" src="https://github.com/user-attachments/assets/c100ded5-54ec-4640-a959-38af5e561e2e" />
(FYI this screenshot was taken on a branch that also had [PR 273](https://github.com/rhashimoto/wa-sqlite/pull/273) applied, but I believe the relative improvement here is generally applicable)

### Checklist
- [x] I grant to recipients of this Project distribution a perpetual,
non-exclusive, royalty-free, irrevocable copyright license to reproduce, prepare
derivative works of, publicly display, sublicense, and distribute this
Contribution and such derivative works.
- [x] I certify that I am legally entitled to grant this license, and that this
Contribution contains no content requiring a license from any third party.
