### PR TITLE
Replace Facade Proxy with handwritten proxy.

### DIFF
--- a/src/examples/MemoryVFS.js
+++ b/src/examples/MemoryVFS.js
@@ -116,7 +116,7 @@ export class MemoryVFS extends FacadeVFS {
     }
 
     // Copy data.
-    new Uint8Array(file.data, iOffset, pData.byteLength).set(pData);
+    new Uint8Array(file.data, iOffset, pData.byteLength).set(pData.subarray());
     file.size = Math.max(file.size, iOffset + pData.byteLength);
     return VFS.SQLITE_OK;
   }


### PR DESCRIPTION
See https://github.com/rhashimoto/wa-sqlite/pull/273

Using [Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) in the Facade implementation is convenient but has a performance cost. It is most noticeable with MemoryVFS and MemoryAsyncVFS; less so with VFS classes where persistent storage API calls (e.g. to OPFS and IndexedDB) become the bottleneck.

This PR replaces the use of Proxy in Facade with handwritten classes that have the same methods as `Uint8Array` and `DataView` for a small performance optimization.