### PR TITLE
Fix WebLocksMixin state initialization.

### DIFF
--- a/src/WebLocksMixin.js
+++ b/src/WebLocksMixin.js
@@ -71,10 +71,8 @@ export const WebLocksMixin = superclass => class extends superclass {
    */
   async jUnlock(fileId, lockType) {
     try {
-      // SQLite can call xUnlock() without ever calling xLock() so
-      // the state may not exist.
       const lockState = this.#getLockState(fileId);
-      if (!(lockType < lockState?.type)) return VFS.SQLITE_OK;
+      if (!(lockType < lockState.type)) return VFS.SQLITE_OK;
   
       switch (this.#options.lockPolicy) {
         case 'exclusive':

--- a/src/WebLocksMixin.js
+++ b/src/WebLocksMixin.js
@@ -119,9 +119,9 @@ export const WebLocksMixin = superclass => class extends superclass {
    * @returns {number|Promise<number>}
    */
   jFileControl(fileId, op, pArg) {
-    const lockState = this.#getLockState(fileId);
     if (op === WebLocksMixin.WRITE_HINT_OP_CODE &&
         this.#options.lockPolicy === 'shared+hint'){
+      const lockState = this.#getLockState(fileId);
       lockState.writeHint = true;
     }
     return VFS.SQLITE_NOTFOUND;

--- a/src/WebLocksMixin.js
+++ b/src/WebLocksMixin.js
@@ -48,18 +48,7 @@ export const WebLocksMixin = superclass => class extends superclass {
    */
   async jLock(fileId, lockType) {
     try {
-      // Create state on first lock.
-      if (!this.#mapIdToState.has(fileId)) {
-        const name = this.getFilename(fileId);
-        const state = {
-          baseName: name,
-          type: VFS.SQLITE_LOCK_NONE,
-          writeHint: false
-        };
-        this.#mapIdToState.set(fileId, state);
-      }
-
-      const lockState = this.#mapIdToState.get(fileId);
+      const lockState = this.#getLockState(fileId);
       if (lockType <= lockState.type) return VFS.SQLITE_OK;
   
       switch (this.#options.lockPolicy) {
@@ -84,7 +73,7 @@ export const WebLocksMixin = superclass => class extends superclass {
     try {
       // SQLite can call xUnlock() without ever calling xLock() so
       // the state may not exist.
-      const lockState = this.#mapIdToState.get(fileId);
+      const lockState = this.#getLockState(fileId);
       if (!(lockType < lockState?.type)) return VFS.SQLITE_OK;
   
       switch (this.#options.lockPolicy) {
@@ -107,7 +96,7 @@ export const WebLocksMixin = superclass => class extends superclass {
    */
   async jCheckReservedLock(fileId, pResOut) {
     try {
-      const lockState = this.#mapIdToState.get(fileId);
+      const lockState = this.#getLockState(fileId);
       switch (this.#options.lockPolicy) {
         case 'exclusive':
           return this.#checkReservedExclusive(lockState, pResOut);
@@ -130,17 +119,27 @@ export const WebLocksMixin = superclass => class extends superclass {
    * @returns {number|Promise<number>}
    */
   jFileControl(fileId, op, pArg) {
-    const lockState = this.#mapIdToState.get(fileId) ??
-      (() => {
-        // Call jLock() to create the lock state.
-        this.jLock(fileId, VFS.SQLITE_LOCK_NONE);
-        return this.#mapIdToState.get(fileId);
-      })();
+    const lockState = this.#getLockState(fileId);
     if (op === WebLocksMixin.WRITE_HINT_OP_CODE &&
         this.#options.lockPolicy === 'shared+hint'){
       lockState.writeHint = true;
     }
     return VFS.SQLITE_NOTFOUND;
+  }
+
+  #getLockState(fileId) {
+    let lockState = this.#mapIdToState.get(fileId);
+    if (!lockState) {
+      // The state doesn't exist yet so create it.
+      const name = this.getFilename(fileId);
+      lockState = {
+        baseName: name,
+        type: VFS.SQLITE_LOCK_NONE,
+        writeHint: false
+      };
+      this.#mapIdToState.set(fileId, lockState);
+    }
+    return lockState
   }
 
   /**


### PR DESCRIPTION
WebLocksMixin was calling the `jLock()` method from `jFileControl()` if its state needed initialization, which was sloppy and enabled a bug if any subclasses implemented their own `jLock()`, like OPFSAdaptiveVFS. This PR moves initialization into a dedicated private method.