### PR TITLE
set up tracing for SQLite execution (sqlite3_trace_v2):

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ EXTENSION_FUNCTIONS_URL = https://www.sqlite.org/contrib/download/extension-func
 EXTENSION_FUNCTIONS_SHA3 = ee39ddf5eaa21e1d0ebcbceeab42822dd0c4f82d8039ce173fd4814807faabfa
 
 # source files
+# TODO: maybe use libtrace only in debug mode
 CFILES = \
 	sqlite3.c \
 	extension-functions.c \
@@ -16,6 +17,7 @@ CFILES = \
 	libhook.c \
 	libprogress.c \
 	libvfs.c \
+	libtrace.c \
 	$(CFILES_EXTRA)
 
 JSFILES = \
@@ -23,7 +25,8 @@ JSFILES = \
 	src/libfunction.js \
 	src/libhook.js \
 	src/libprogress.js \
-	src/libvfs.js
+	src/libvfs.js \
+	src/libtrace.js
 
 vpath %.c src
 vpath %.c deps
@@ -77,7 +80,8 @@ EMFLAGS_LIBRARIES = \
 	--post-js src/libfunction.js \
 	--post-js src/libhook.js \
 	--post-js src/libprogress.js \
-	--post-js src/libvfs.js
+	--post-js src/libvfs.js \
+	--post-js src/libtrace.js
 
 EMFLAGS_ASYNCIFY_COMMON = \
 	-s ASYNCIFY \

--- a/src/libadapters.h
+++ b/src/libadapters.h
@@ -22,6 +22,7 @@ DECLARE(void, vppp, P, P, P);
 DECLARE(I, ipppj, P, P, P, J);
 DECLARE(I, ipppi, P, P, P, I);
 DECLARE(I, ipppp, P, P, P, P);
+DECLARE(I, ippipp, P, P, I, P, P);
 DECLARE(I, ipppip, P, P, P, I, P);
 DECLARE(void, vpppip, P, P, P, I, P);
 DECLARE(I, ippppi, P, P, P, P, I);

--- a/src/libadapters.js
+++ b/src/libadapters.js
@@ -6,6 +6,7 @@ const SIGNATURES = [
   'ipppj', // xTruncate
   'ipppi', // xSleep, xSync, xLock, xUnlock, xShmUnmap
   'ipppp', // xFileSize, xCheckReservedLock, xCurrentTime, xCurrentTimeInt64
+  'ippipp', // xTrace
   'ipppip', // xFileControl, xRandomness, xGetLastError
   'vpppip', // xFunc, xStep
   'ippppi', // xDelete

--- a/src/libtrace.c
+++ b/src/libtrace.c
@@ -1,0 +1,19 @@
+#include <emscripten.h>
+#include <sqlite3.h>
+#include <stdio.h>
+
+#include "libadapters.h"
+
+#define CALL_JS(SIGNATURE, KEY, ...)                                           \
+  (asyncFlags ? SIGNATURE##_async(KEY, __VA_ARGS__)                            \
+              : SIGNATURE(KEY, __VA_ARGS__))
+
+static int libtrace_xTrace(unsigned opCode, void *pApp, void *P, void *X) {
+  const int asyncFlags = pApp ? *(int *)pApp : 0;
+  return CALL_JS(ippipp, pApp, pApp, opCode, P, X);
+}
+
+void EMSCRIPTEN_KEEPALIVE libtrace_trace(sqlite3 *db, unsigned mTrace,
+                                         int xTrace, void *pApp) {
+  sqlite3_trace_v2(db, mTrace, xTrace ? &libtrace_xTrace : NULL, pApp);
+}

--- a/src/libtrace.js
+++ b/src/libtrace.js
@@ -1,0 +1,28 @@
+// Copyright 2024 Roy T. Hashimoto. All Rights Reserved.
+// This file should be included in the build with --post-js.
+(function() {
+  const AsyncFunction = Object.getPrototypeOf(async function() { }).constructor;
+  let pAsyncFlags = 0;
+
+  Module['trace'] = function(db, mTrace, xTrace) {
+    if (pAsyncFlags) {
+      Module['deleteCallback'](pAsyncFlags);
+      Module['_sqlite3_free'](pAsyncFlags);
+      pAsyncFlags = 0;
+    }
+
+    pAsyncFlags = Module['_sqlite3_malloc'](4);
+    setValue(pAsyncFlags, xTrace instanceof AsyncFunction ? 1 : 0, 'i32');
+
+    ccall(
+      'libtrace_trace',
+      'void',
+      ['number', 'number', 'number', 'number'],
+      [db, mTrace, xTrace ? 1 : 0, pAsyncFlags]);
+    if (xTrace) {
+      Module['setCallback'](pAsyncFlags, (_, opCode, pP, pX) => {
+        return xTrace(opCode, pP, pX)
+      });
+    }
+  };
+})();

--- a/src/sqlite-constants.js
+++ b/src/sqlite-constants.js
@@ -273,3 +273,8 @@ export const SQLITE_LIMIT_WORKER_THREADS      = 11;
 export const SQLITE_PREPARE_PERSISTENT = 0x01;
 export const SQLITE_PREPARE_NORMALIZED = 0x02;
 export const SQLITE_PREPARE_NO_VTAB = 0x04;
+
+export const SQLITE_TRACE_STMT = 0x01;
+export const SQLITE_TRACE_PROFILE = 0x02;
+export const SQLITE_TRACE_ROW = 0x04;
+export const SQLITE_TRACE_CLOSE = 0x08;

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -849,6 +849,11 @@ declare interface SQLiteAPI {
    * @returns `SQLITE_OK` (throws exception on error)
    */
   vfs_register(vfs: SQLiteVFS, makeDefault?: boolean): number;
+
+  trace(
+    db: number, mTrace: 1 | 2 | 3 | 4,
+    xTrace: (opCode: 1 | 2 | 3 | 4, opStr: string, sql?: string) => number
+  ): void
 }
 
 /** @ignore */


### PR DESCRIPTION
I've found `sqlite3_trace_v2` incredibly useful for debugging an issue I was working on. I've followed the conventions used in rest of the `lib*.(js|c)` shims and `sqlite-api.js` and thought this might be a good candidate to include in the project.

Only the `SQLITE_TRACE_STMT` is currently handled (only one I needed) and I'm opening this as a draft as some thing should be clarified:
- does it even make sense to include this in the project
- should trace shims only be included in demo builds
- should we also derive some data from the prepared statement (does that even make sense) -- currently only the SQL of the statement is reported

I would love to get your thoughts and, if green-lit, impl the support for other trace variants.

Progress:
* create 'libtrace.c' shim (for registering of trace callbacks)
* add JS-side shims for tracing
* TODO: only SQLITE_TRACE_STMT is currently supported: support other trace messages

### Checklist
- [x] I grant to recipients of this Project distribution a perpetual,
non-exclusive, royalty-free, irrevocable copyright license to reproduce, prepare
derivative works of, publicly display, sublicense, and distribute this
Contribution and such derivative works.
- [x] I certify that I am legally entitled to grant this license, and that this
Contribution contains no content requiring a license from any third party.
