### PR TITLE
Fix salt association across WAL boundary.

### DIFF
--- a/src/examples/WriteAhead.js
+++ b/src/examples/WriteAhead.js
@@ -775,7 +775,7 @@ export class WriteAhead {
       id: 0, // placeholder
       pages: new Map(),
       dbFileSize: 0, // placeholder
-      waSalt1: this.#activeHeader.salt1,
+      waSalt1: 0, // placeholder
       waOffsetEnd: 0, // placeholder
     };
 
@@ -793,7 +793,7 @@ export class WriteAhead {
           {
             pageSize: frame.pageData.byteLength,
             waOffset: offset + FRAME_HEADER_SIZE,
-            waSalt1: tx.waSalt1,
+            waSalt1: this.#activeHeader.salt1,
           }
         );
       } else if (frame.frameType === FRAME_TYPE_COMMIT) {
@@ -804,6 +804,7 @@ export class WriteAhead {
         // Finalize the transaction fields and return it.
         tx.id = this.#txId;
         tx.dbFileSize = frame.dbFileSize;
+        tx.waSalt1 = this.#activeHeader.salt1;
         tx.newPageSize = (frame.flags & 1) ? tx.pages.get(0).pageSize : null;
         tx.waOffsetEnd = this.#activeOffset;
         return tx;
@@ -881,8 +882,8 @@ export class WriteAhead {
       throw new Error('write failed');
     }
 
-    // Add the page to the transaction map. Cache page 1 as a performance
-    // optimization and to exercise the cache code path.
+    // Cache page 1 as a performance optimization and to exercise the
+    // cache code path.
     const pageEntry = {
       pageSize: pageData.byteLength,
       waOffset: this.#txInProgress.waOffsetEnd + FRAME_HEADER_SIZE,


### PR DESCRIPTION
Fix #320.

When loading a transaction from the WAL, if the load starts on one WAL file, reads the end record, and moves to the other WAL file, then the wrong file identifier (the waSalt1 property) was set on all the pages on that transaction. This could cause reads from the wrong WAL file which would appear as database corruption errors.