### PR TITLE
Preserve embedded NUL bytes in TEXT values

### DIFF
--- a/src/sqlite-api.js
+++ b/src/sqlite-api.js
@@ -224,8 +224,16 @@ export function Factory(Module) {
     const f = Module.cwrap(fname, ...decl('nnnnn:n'));
     return function(stmt, i, value) {
       verifyStatement(stmt);
-      const ptr = createUTF8(value);
-      const result = f(stmt, i, ptr, -1, sqliteFreeAddress);
+      let ptr = 0;
+      let nBytes = -1;
+      if (typeof value === 'string') {
+        const utf8 = textEncoder.encode(value);
+        ptr = Module._sqlite3_malloc(utf8.byteLength + 1);
+        Module.HEAPU8.set(utf8, ptr);
+        Module.HEAPU8[ptr + utf8.byteLength] = 0;
+        nBytes = utf8.byteLength;
+      }
+      const result = f(stmt, i, ptr, nBytes, sqliteFreeAddress);
       return check(fname, result, mapStmtToDB.get(stmt));
     };
   })();
@@ -369,11 +377,26 @@ export function Factory(Module) {
 
   sqlite3.column_text = (function() {
     const fname = 'sqlite3_column_text';
-    const f = Module.cwrap(fname, ...decl('nn:s'));
+    const f = Module.cwrap(fname, ...decl('nn:n'));
     return function(stmt, iCol) {
       verifyStatement(stmt);
-      const result = f(stmt, iCol);
-      return result;
+      const address = f(stmt, iCol);
+      const nBytes = sqlite3.column_bytes(stmt, iCol);
+      const parts = [];
+      let start = 0;
+      for (let end = 0; end < nBytes; ++end) {
+        if (Module.HEAPU8[address + end] === 0) {
+          if (start < end) {
+            parts.push(Module.UTF8ToString(address + start, end - start));
+          }
+          parts.push('\0');
+          start = end + 1;
+        }
+      }
+      if (start < nBytes) {
+        parts.push(Module.UTF8ToString(address + start, nBytes - start));
+      }
+      return parts.join('');
     };
   })();
 

--- a/test/api_statements.js
+++ b/test/api_statements.js
@@ -238,6 +238,39 @@ export function api_statements(context) {
       }
     });
 
+    it('should bind text with NUL bytes', async function() {
+      let rc;
+      const sql = 'SELECT hex(?)';
+      const value = 'Before\0After';
+
+      for await (const stmt of i(sqlite3.statements(db, sql))) {
+        rc = await sqlite3.bind_text(stmt, 1, value);
+        expect(rc).toEqual(SQLite.SQLITE_OK);
+
+        while ((rc = await sqlite3.step(stmt)) !== SQLite.SQLITE_DONE) {
+          expect(rc).toEqual(SQLite.SQLITE_ROW);
+          expect(await sqlite3.column_text(stmt, 0)).toEqual(
+            '4265666F7265004166746572'
+          );
+        }
+      }
+    });
+
+    it('should read text with NUL bytes', async function() {
+      let rc;
+      const sql = "SELECT char(65279) || 'Before' || char(0) || 'After'";
+      const value = '\uFEFFBefore\0After';
+
+      for await (const stmt of i(sqlite3.statements(db, sql))) {
+        while ((rc = await sqlite3.step(stmt)) !== SQLite.SQLITE_DONE) {
+          expect(rc).toEqual(SQLite.SQLITE_ROW);
+          expect(await sqlite3.column_bytes(stmt, 0)).toEqual(15);
+          expect(await sqlite3.column_text(stmt, 0)).toEqual(value);
+          expect(await sqlite3.column(stmt, 0)).toEqual(value);
+        }
+      }
+    });
+
     it('should bind boolean', async function() {
       let rc;
       const sql = 'SELECT ?';


### PR DESCRIPTION
## Summary

- pass the encoded UTF-8 byte length to `sqlite3_bind_text` so embedded NUL bytes are not treated as a C-string terminator
- read `sqlite3_column_text` with its `sqlite3_column_bytes` length and preserve embedded NULs without changing the existing Emscripten UTF-8 decoding behavior
- add independent regression coverage for the bind and read paths

## Testing

- `yarn test` under Node 20 and Chrome: 2,993 passed, 0 failed
- with the original implementation, both new tests fail across the storage/build matrix while the existing 2,114 assertions pass
- `node --check src/sqlite-api.js`

## References

- SQLite's [`sqlite3_bind_text` contract](https://www.sqlite.org/c3ref/bind_blob.html) specifies that a negative byte length stops at the first NUL, while an explicit non-negative length preserves embedded NULs.
- SQLite's [column-value contract](https://www.sqlite.org/c3ref/column_blob.html) defines `sqlite3_column_bytes` as the full UTF-8 byte length and recommends calling `sqlite3_column_text` before `sqlite3_column_bytes`.
- SQLite [explicitly supports embedded NULs in stored TEXT](https://www.sqlite.org/nulinstr.html), while documenting caveats for some SQL functions and CLI rendering.

### Checklist

- [x] I grant to recipients of this Project distribution a perpetual,
non-exclusive, royalty-free, irrevocable copyright license to reproduce, prepare
derivative works of, publicly display, sublicense, and distribute this
Contribution and such derivative works.
- [x] I certify that I am legally entitled to grant this license, and that this
Contribution contains no content requiring a license from any third party.

